### PR TITLE
PSO Drop Chart Search feature

### DIFF
--- a/Drop Charts/init.lua
+++ b/Drop Charts/init.lua
@@ -745,4 +745,4 @@ return {
   __addon = {
     init = init
   }
-}}
+}

--- a/Drop Charts/init.lua
+++ b/Drop Charts/init.lua
@@ -11,13 +11,10 @@ local drop_charts = {
 }
 
 -- window vars
-local window_open = true
+local window_open = false
 local button_func = function()
   window_open = not window_open
 end
-local windowArgs = {
-	"NoMove"
-}
 
 -- memory addresses
 local _SideMessage = pso.base_address + 0x006AECC8
@@ -154,7 +151,7 @@ end
 -- End Soly
 
 -- create an ASCII separator
-local separator = "+" .. string.rep("-", 86) .. "+"
+local separator = "+" .. string.rep("-", 86) .. "+" 
 local function Separator(noNewLine)
   if noNewLine == nil then
     imgui.NewLine()
@@ -696,11 +693,11 @@ end
 
 -- show the drop charts when opened
 local function present()
-  -- if window_open then
+  if window_open then
 	counter = counter + 1
     local status, dataFound = false
     imgui.SetNextWindowSize(700, 520, "FirstUseEver");
-    status, window_open = imgui.Begin("Drop Charts", window_open, windowArgs)
+    status, window_open = imgui.Begin("Drop Charts", window_open)
 	-- @todo: using counter prevents auto mode from updating upon party changes
     -- if counter % update_interval == 0 then
         local side = get_side_text()
@@ -725,7 +722,7 @@ local function present()
 	end
 	
     imgui.End()
-  -- end
+  end
 end
 
 


### PR DESCRIPTION
Hi Seth! I'm not sure if you are still on PSO at all. I came back recently, although not sure how much I'll be on there. But for some reason, I got the urge to add a search feature to the Drop Charts.

It allows you to search for any item within the scope of the selected Difficulty and Section, or even just for any item across all difficulties and section ID's. If, for example, you wanted to know which enemies and section ID's dropped a particular item.

If you find yourself on here/there, you're welcome to examine and pull it, if you'd like. 